### PR TITLE
Adding additional actions, manual trigger inputs, and some comparison operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ package = Package("incremental_test",flow)
 package.export_zipfile()
 ```
 
-This example creates manual trigger and 2 actions. Then export the flow as lagacy package(zip file).
+This example creates manual trigger and 2 actions. Then export the flow as legacy package(zip file).
 You can import the flow by uploading `incremental_test.zip` to Power Automate. 
 
 ## Supported Triggers
@@ -55,7 +55,7 @@ You can import the flow by uploading `incremental_test.zip` to Power Automate.
 - Variable
 - Conditionals
 - Loops
-- Data Operetions
+- Data Operations
 - Time
 - HTTP (requires Premium subscription)
 
@@ -92,7 +92,7 @@ We aim to provide all contributors and maintainers with a safe and positive expe
 
 - Respect Each Other: Treat everyone working on the project respectfully, regardless of background.
 
-- Promote Inclusivity: Actively promote inclusivity and welcome diverse perspectives.
+- Promote Inclusively: Actively promote inclusively and welcome diverse perspectives.
 
 - Maintain a Harassment-Free Environment: Avoid any behavior seen as harassment and maintain a harassment-free environment.
 

--- a/src/pypowerautomate/actions/condition.py
+++ b/src/pypowerautomate/actions/condition.py
@@ -9,6 +9,9 @@ precedence = {
     "<": 4,
     ">=": 4,
     "<=": 4,
+    "contains": 4,
+    "startswith": 4,
+    "endswith": 4,
     "not": 3,
     "and": 2,
     "or": 1
@@ -21,6 +24,9 @@ operator_mapping = {
     "<=": "lessOrEquals",
     ">": "greater",
     "<": "less",
+    "contains": "contains",
+    "startswith": "startsWith",
+    "endswith": "endsWith",
     "and": "and",
     "or": "or",
     "not": "not",
@@ -78,7 +84,7 @@ def tokenizer(s):
     Returns:
         list: A list of tokens extracted from the input string.
     """
-    keywords = ['and', 'or', 'not', 'true', 'false']
+    keywords = ['and', 'or', 'not', 'true', 'false', "contains", "startswith", "endswith"]
     operators = ['!=', '==', '>=', '<=', '>', '<']
     tokens = []
     token = ''
@@ -193,10 +199,10 @@ def create_ast(rpn_tokens):
     stack = []
     for token in rpn_tokens:
         # If token is a number or a variable
-        if token not in precedence and token not in ["==", "!=", ">", "<", ">=", "<="]:
+        if token not in precedence and token not in ["==", "!=", ">", "<", ">=", "<=", "contains", "startswith", "endswith"]:
             stack.append({"type": "Literal", "value": token})
         else:  # If token is an operator
-            if token in ["==", "!=", ">", "<", ">=", "<="]:  # binary operators
+            if token in ["==", "!=", ">", "<", ">=", "<=", "contains", "startswith", "endswith"]:  # binary operators
                 right = stack.pop() if stack else None
                 left = stack.pop() if stack else None
                 if right is None or left is None:

--- a/src/pypowerautomate/actions/dataoperation.py
+++ b/src/pypowerautomate/actions/dataoperation.py
@@ -153,3 +153,32 @@ class JoinAction(BaseAction):
         """
         d = {"metadata": self.metadata, "type": self.type, "runAfter": self.runafter, "inputs": self.inputs}
         return d
+
+
+class ParseJSONAction(BaseAction):
+    """
+    Defines an action to parse JSON based on a given schema
+    """
+    
+    def __init__(self, name: str, content: str, schema: dict):
+        """
+        Initializes a new instance of ParseJSON.
+
+        Args:
+            name (str): The name of the action.
+            content (str): The data to be turned into a JSON object
+            schema (dict): The schema of the expected JSON object
+        """
+        super().__init__(name)
+        self.type = "ParseJSON"
+        self.inputs = {"content": content, "schema": schema}
+
+    def export(self) -> Dict:
+        """
+        Exports the configuration of the ParseJSON for use in a workflow.
+
+        Returns:
+            Dict: A dictionary containing the configuration of this action.
+        """
+        d = {"metadata": self.metadata, "type": self.type, "runAfter": self.runafter, "inputs": self.inputs}
+        return d

--- a/src/pypowerautomate/actions/sharepoint.py
+++ b/src/pypowerautomate/actions/sharepoint.py
@@ -711,6 +711,74 @@ class SharepointExtractFolderV2Action(BaseAction):
 
         return d
 
+METHODS = set(["GET", "PUT", "POST", "PATCH", "DELETE"])
+
+class SharepointHTTPRequestAction(BaseAction):
+    """
+    Defines an action to send an HTTP request to Sharepoint. This is different to the other HTTP action as it does not require a premium license, but is only restricted to access Sharepoint sites.
+    """
+
+    connection_host = {
+        "connectionName": "shared_sharepointonline",
+        "operationId": "HttpRequest",
+        "apiId": "/providers/Microsoft.PowerApps/apis/shared_sharepointonline"
+    }
+
+    def __init__(self, name: str, dataset: str, method: str, uri: str, headers: dict = None, body: str = None):
+        """
+        Initializes a new Sharepoint HTTP Request with specified parameters.
+
+        Args:
+            name (str): The name of the action.
+            dataset (str): The base URL of the Sharepoint site.
+            method (str): The method of the HTTP request. Can be GET, PUT, POST, PATCH, or DELETE.
+            uri (str): The second part of the URL.
+            headers (dict): The headers to be used with this HTTP request.
+            body (str): The body of the HTTP request.
+        """
+        
+        super().__init__(name)
+        self.type = "OpenApiConnection"
+
+        self.dataset: str = dataset
+
+        if method not in METHODS:
+            raise ValueError("Unsupported method type")
+
+        self.method: str = method
+        self.uri: str = uri
+        self.headers: dict = headers
+        self.body: str = body
+
+    def export(self) -> Dict:
+        """
+        Exports the current state and configuration of the HTTP action in a dictionary format suitable for JSON serialization.
+
+        Returns:
+            Dict: A dictionary containing all the inputs and settings of the HTTP action.
+        """
+
+        inputs = {}
+        parameters = {} 
+
+        parameters["dataset"] = self.dataset
+        parameters["parameters/method"] = self.method
+        parameters["parameters/uri"] = self.uri
+        if self.headers:
+            parameters["parameters/headers"] = self.headers
+        if self.body:
+            parameters["parameters/body"] = self.body
+
+        inputs["host"] = SharepointHTTPRequestAction.connection_host
+        inputs["parameters"] = parameters
+
+        d = {}
+        d["metadata"] = self.metadata
+        d["type"] = self.type
+        d["runAfter"] = self.runafter
+        d["inputs"] = inputs
+
+        return d
 
 class SharepointXxxxxxAction(BaseAction):
     connection_host = {

--- a/src/pypowerautomate/actions/sharepoint.py
+++ b/src/pypowerautomate/actions/sharepoint.py
@@ -733,8 +733,8 @@ class SharepointHTTPRequestAction(BaseAction):
             dataset (str): The base URL of the Sharepoint site.
             method (str): The method of the HTTP request. Can be GET, PUT, POST, PATCH, or DELETE.
             uri (str): The second part of the URL.
-            headers (dict): The headers to be used with this HTTP request.
-            body (str): The body of the HTTP request.
+            headers (dict, optional): The headers to be used with this HTTP request.
+            body (str, optional): The body of the HTTP request.
         """
         
         super().__init__(name)

--- a/src/pypowerautomate/actions/statements.py
+++ b/src/pypowerautomate/actions/statements.py
@@ -50,8 +50,15 @@ class IfStatement(BaseAction):
         d["type"] = self.type
         d["runAfter"] = self.runafter
         d["expression"] = self.condition.export()
-        d["actions"] = self.true_actions.export()
-        d["else"] = {"actions": self.false_actions.export()}
+
+        if self.true_actions:
+            d["actions"] = self.true_actions.export()
+        else:
+            d["actions"] = {}
+
+        if self.false_actions:
+            d["else"] = {"actions": self.false_actions.export()}
+
         return d
 
 

--- a/src/pypowerautomate/triggers/__init__.py
+++ b/src/pypowerautomate/triggers/__init__.py
@@ -1,1 +1,1 @@
-from .trigger import BaseTrigger, Triggers, ManualTrigger, RecurrenceTrigger
+from .trigger import BaseTrigger, Triggers, ManualTrigger, RecurrenceTrigger, TriggerInputVariableType

--- a/src/pypowerautomate/triggers/trigger.py
+++ b/src/pypowerautomate/triggers/trigger.py
@@ -8,6 +8,9 @@ class TriggerInputVariableType:
     email = {"name": "Email", "type": "string", "hint": "EMAIL", "format": "email"}
     number = {"name": "Number", "type": "number", "hint": "NUMBER"}
     date = {"name": "Date", "type": "string", "hint": "DATE", "format": "date"}
+
+    # The following two types aren't directly selectable by the normal input in PowerAutomate
+    # You can see them by selecting the "Text" type and clicking the 3 dots menu
     multi_select = {"name": "Multi-Select", "type": "array", "hint": "TEXT"}
     dropdown = {"name": "Dropdown", "type": "string", "hint": "TEXT"}
 
@@ -166,8 +169,8 @@ class ManualTrigger(BaseTrigger):
             type (dict): The type of variable, defined in TriggerInputVariableType
             title (str): The title of the input. Must be unique.
             description (str): The description of the input.
-            required (bool): Sets if the variable is required or not. Optional, Default: True
-            options (list[str]): A list containing options for the input. Only available if type is dropdown or multi_select. Optional, Default: None
+            required (bool, optional): Sets if the variable is required or not.
+            options (list[str], optional): A list containing options for the input. Only available if type is dropdown or multi_select.
         """
 
         if title in self.inputs["schema"]["properties"]:


### PR DESCRIPTION
Hello!

First of all, I want to thank you all so much for creating this project. This is exactly what I was looking for to work with Power Automate flows.

I've added in some actions and other things, and I'll describe what I did here.

For the first commit, I added in some actions, and updated the manual trigger to allow for inputs. More info about them is down below in the commit message. The two new actions are for ParseJSON and Sharepoint HTTP Request. I created the latter one because it does not require a premium license like the global HTTP request. 

In the second commit, I added some binary operators for contains, startswith, and endswith, to mirror the Power Automate comparisons of the same name. I figured that instead of making ones for does not contain, does not start with, and does not end with was not needed since the unary 'not' operator exists to negate the normal ones.

There were also some spelling mistakes I cleaned up in README.md.

If you have any questions or comments, please let me know! 
I'm planning on adding some more actions at a later point, and I'll be looking into adding some triggers as well.

Thanks,
Trevor W.